### PR TITLE
Add null checks for device name and model in Deye inverter detection

### DIFF
--- a/custom_components/qilowatt/config_flow.py
+++ b/custom_components/qilowatt/config_flow.py
@@ -86,7 +86,7 @@ class QilowattConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         "name": device.name,
                         "inverter_integration": "Huawei",
                     }
-            if "Deye" in device.name and "esp32" in device.model:
+            if (device.name and "Deye" in device.name) and (device.model and "esp32" in device.model):
                 inverters[device.id] = {
                     "name": device.name,
                     "inverter_integration": "EspHome",


### PR DESCRIPTION
Fixes TypeError in config flow when device.model or device.name is None during Deye inverter detection.