### PR TITLE
Add Victron inverter support and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ The `qilowatt-ha` integration relies on existing HA integrations to discover and
     -   Via **SolaX Modbus**: Requires the [wills106/homeassistant-solax-modbus](https://github.com/wills106/homeassistant-solax-modbus) integration.
 -   **Huawei:**
     -   Via **Huawei Solar**: Requires the [wlcrs/huawei_solar](https://github.com/wlcrs/huawei_solar) integration.
--   **Victron & others:** Support for other inverters is often added by the community.
+-   **Victron: **
+    -   Via ** Victron for QW**: - Requires https://github.com/mnuxx/victron_qw_addon
 
 ---
 

--- a/custom_components/qilowatt/config_flow.py
+++ b/custom_components/qilowatt/config_flow.py
@@ -31,7 +31,7 @@ class QilowattConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     selected_device_id
                 ]["inverter_integration"]
                 return self.async_create_entry(
-                    title=available_inverters[selected_device_id]["name"],
+                    title=f"{available_inverters[selected_device_id]['name']}",
                     data=user_input,
                 )
 
@@ -88,7 +88,7 @@ class QilowattConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     }
                 # Victron integrations can appear under multiple domains
                 # Commonly via Victron integration or Modbus; also check manufacturer/name
-                if domain in ("victron", "modbus") or (device.manufacturer and "Victron" in device.manufacturer):
+                if domain == "victron_qw_addon" :
                     inverters[device.id] = {
                         "name": device.name or device_id,
                         "inverter_integration": "Victron",

--- a/custom_components/qilowatt/config_flow.py
+++ b/custom_components/qilowatt/config_flow.py
@@ -31,7 +31,7 @@ class QilowattConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     selected_device_id
                 ]["inverter_integration"]
                 return self.async_create_entry(
-                    title=f"{available_inverters[selected_device_id]["name"]}",
+                    title=available_inverters[selected_device_id]["name"],
                     data=user_input,
                 )
 
@@ -85,6 +85,13 @@ class QilowattConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     inverters[device.id] = {
                         "name": device.name,
                         "inverter_integration": "Huawei",
+                    }
+                # Victron integrations can appear under multiple domains
+                # Commonly via Victron integration or Modbus; also check manufacturer/name
+                if domain in ("victron", "modbus") or (device.manufacturer and "Victron" in device.manufacturer):
+                    inverters[device.id] = {
+                        "name": device.name or device_id,
+                        "inverter_integration": "Victron",
                     }
             if (device.name and "Deye" in device.name) and (device.model and "esp32" in device.model):
                 inverters[device.id] = {

--- a/custom_components/qilowatt/config_flow.py
+++ b/custom_components/qilowatt/config_flow.py
@@ -86,9 +86,8 @@ class QilowattConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         "name": device.name,
                         "inverter_integration": "Huawei",
                     }
-                # Victron integrations can appear under multiple domains
-                # Commonly via Victron integration or Modbus; also check manufacturer/name
-                if domain == "victron_qw_addon" :
+                if domain == "victron_qw_addon":
+                    # Victron inverter integration
                     inverters[device.id] = {
                         "name": device.name or device_id,
                         "inverter_integration": "Victron",

--- a/custom_components/qilowatt/inverter/__init__.py
+++ b/custom_components/qilowatt/inverter/__init__.py
@@ -3,6 +3,7 @@ from .solarassistant import SolarAssistantInverter
 from .solarman import SolarmanInverter
 from .sofar import SofarInverter
 from .esphome import EspHomeInverter
+from .victron import VictronInverter
 
 # from .deye_synsynk import SynsynkInverter
 # from .growatt import GrowattInverter
@@ -14,6 +15,7 @@ INVERTER_INTEGRATIONS = {
     "Sofar": SofarInverter,
     "Huawei": HuaweiInverter,
     "EspHome": EspHomeInverter,
+    "Victron": VictronInverter,
 }
 
 

--- a/custom_components/qilowatt/inverter/victron.py
+++ b/custom_components/qilowatt/inverter/victron.py
@@ -1,0 +1,132 @@
+import logging
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from qilowatt import EnergyData, MetricsData
+
+from .base_inverter import BaseInverter
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class VictronInverter(BaseInverter):
+    """Implementation for Victron cerbo  integrated inverters."""
+
+    def __init__(self, hass: HomeAssistant, config_entry):
+        super().__init__(hass, config_entry)
+        self.hass = hass
+        self.device_id = config_entry.data["device_id"]
+        self.entity_registry = er.async_get(hass)
+        self.inverter_entities = {}
+        for entity in self.entity_registry.entities.values():
+            if entity.device_id == self.device_id:
+                self.inverter_entities[entity.entity_id] = entity.name
+
+    def find_entity_state(self, entity_id):
+        """Helper method to find a state by entity_id."""
+        return next(
+            (
+                self.hass.states.get(entity)
+                for entity in self.inverter_entities
+                if entity.endswith(entity_id)
+            ),
+            None,
+        )
+
+    def get_state_float(self, entity_id, default=0.0):
+        """Helper method to get a sensor state as float."""
+
+        state = self.find_entity_state(entity_id)
+        if state and state.state not in ("unknown", "unavailable", ""):
+            try:
+                return float(state.state)
+            except ValueError:
+                _LOGGER.warning(f"Could not convert state of {entity_id} to float")
+        else:
+            _LOGGER.warning(f"State of {entity_id} is unavailable or unknown")
+        return default
+
+    def get_state_int(self, entity_id, default=0):
+        """Helper method to get a sensor state as int."""
+        state = self.find_entity_state(entity_id)
+        if state and state.state not in ("unknown", "unavailable", ""):
+            try:
+                return int(float(state.state))
+            except ValueError:
+                _LOGGER.warning(f"Could not convert state of {entity_id} to int")
+        else:
+            _LOGGER.warning(f"State of {entity_id} is unavailable or unknown")
+        return default
+
+    def get_energy_data(self):
+        """Retrieve ENERGY data."""
+        power = [
+            self.get_state_float("victron_qw_grid_l1"),
+            self.get_state_float("victron_qw_grid_l2"),
+            self.get_state_float("victron_qw_grid_l3"),
+        ]
+        today = self.get_state_float("today_energy_import")
+        total = 0.0  # As per payload
+        voltage = [
+            self.get_state_float("victron_qw_input_voltage_phase_1"),
+            self.get_state_float("victron_qw_input_voltage_phase_2"),
+            self.get_state_float("victron_qw_input_voltage_phase_3"),
+        ]
+        current = [round(x / y, 2) if y else 0 for x, y in zip(power, voltage)]
+        frequency = self.get_state_float("victron_qw_grid_frequency")
+
+        return EnergyData(
+            Power=power,
+            Today=today,
+            Total=total,
+            Current=current,
+            Voltage=voltage,
+            Frequency=frequency,
+        )
+
+    def get_metrics_data(self):
+        """Retrieve METRICS data."""
+        pv_power = [
+            self.get_state_float("total_pv_power"),
+            self.get_state_float("pv2_power"),
+        ]
+        pv_voltage = [
+            self.get_state_float("pv1_voltage"),
+            self.get_state_float("pv2_voltage"),
+        ]
+        pv_current = [
+            self.get_state_float("pv1_current"),
+            self.get_state_float("pv2_current"),
+        ]
+        load_power = [
+            self.get_state_float("victron_qw_ac_consumption_l1"),
+            self.get_state_float("victron_qw_ac_consumption_l2"),
+            self.get_state_float("victron_qw_ac_consumption_l3"),
+        ]
+        alarm_codes = [0, 0, 0, 0, 0, 0]  # As per payload
+        battery_soc = self.get_state_int("victron_qw_battery_state_of_charge")
+        load_current = [0.0, 0.0, 0.0]  # As per payload
+        battery_power = [self.get_state_float("victron_qw_battery_power")]
+        battery_current = [self.get_state_float("victron_qw_battery_current")]
+        battery_voltage = [self.get_state_float("victron_qw_battery_voltage")]
+        inverter_status = 2  # As per payload
+        grid_export_limit = self.get_state_float("sell_limit_2")
+        battery_temperature = [self.get_state_float("victron_qw_battery_temperature")]
+        inverter_temperature = self.get_state_float("victron_qw_battery_temperature")
+
+        return MetricsData(
+            PvPower=pv_power,
+            PvVoltage=pv_voltage,
+            PvCurrent=pv_current,
+            LoadPower=load_power,
+            AlarmCodes=alarm_codes,
+            BatterySOC=battery_soc,
+            LoadCurrent=load_current,
+            BatteryPower=battery_power,
+            BatteryCurrent=battery_current,
+            BatteryVoltage=battery_voltage,
+            InverterStatus=inverter_status,
+            GridExportLimit=grid_export_limit,
+            BatteryTemperature=battery_temperature,
+            InverterTemperature=inverter_temperature,
+        )


### PR DESCRIPTION
This PR adds support for Victron inverters to the Qilowatt Home Assistant integration.

Changes:
- Added Victron inverter class in custom_components/qilowatt/inverter/victron.py
- Updated config_flow.py to detect Victron inverters
- Updated __init__.py to include Victron
- Updated README.md with Victron support information

Fixes:
- Fixed Victron detection to use 'victron_qw_addon' domain